### PR TITLE
Update and fix greetings workflow

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,16 @@
 name: Greetings
 
-on: [pull_request, issues]
+on:
+  pull_request:
+    types:
+      - opened
+  issues:
+    types:
+      - opened
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   greeting:
@@ -8,6 +18,5 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-message: "Thanks for opening your first issue. Pull requests are always welcome too! :)"
           pr-message: "Thank you for your contribution. We will be reviewing your PR shortly! In the meantime, please make sure all status checks have passed."

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -18,5 +18,5 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          issue-message: "Thanks for opening your first issue. Pull requests are always welcome too! :)"
-          pr-message: "Thank you for your contribution. We will be reviewing your PR shortly! In the meantime, please make sure all status checks have passed."
+          issue_message: "Thanks for opening your first issue. Pull requests are always welcome too! :)"
+          pr_message: "Thank you for your contribution. We will be reviewing your PR shortly! In the meantime, please make sure all status checks have passed."


### PR DESCRIPTION
Closes #157

Based on the usage example in the README:
https://github.com/actions/first-interaction/tree/v3.1.0?tab=readme-ov-file#usage

For me the workflow was previously failing when I created my first issue in this repository here:
https://github.com/azagniotov/language-detection/actions/runs/18820093258/job/53694233157
```
...
Checking if its the users first contribution
Adding message: Thanks for opening your first issue. Pull requests are always welcome too! :) to issue 166
Error: Resource not accessible by integration - https://docs.github.com/rest/issues/comments#create-an-issue-comment
```

I am not completely sure if this change fully solves the problem for external contributors. Because normally `pull_request` runs with read-only permissions (which cannot be increased to write permission, e.g. `pull-requests: write`), unless GitHub added some special casing for `actions/first-interaction`?
But let's see once you approve the workflows for this PR whether the workflow is able to add a comment here.