### PR TITLE
Only run dependency submission workflow for push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
           git push
 
   dependency-submission:
+    if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Previously it was also running for pull requests, which is probably undesired, and also failed if the PR was from an external contributor.

(This was also the cause for the CI failure in #168)