### PR TITLE
Don't extract benchmark dataset to `build/resources`

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Currently, the following libraries are evaluated in terms of accuracy and speed 
 
 ### Running the benchmarks
 
-Please note that the test dataset is quite large when unzipped. When running the benchmarks for the first time, the dataset located in [src/benchmarkTest/dataset.tar.gz](src/benchmarkTest/dataset.tar.gz) (approximately 95 MB) will be extracted into the `build/resources/benchmarkTest` directory. This extraction requires about **1.05 GB** of disk space.
+Please note that the test dataset is quite large when unzipped. When running the benchmarks for the first time, the dataset located in [src/benchmarkTest/dataset.tar.gz](src/benchmarkTest/dataset.tar.gz) (approximately 95 MB) will be extracted into the `build/benchmarkTestDataset` directory. This extraction requires about **1.05 GB** of disk space.
 
 To run benchmarks across all the libraries and datasets, execute the following Gradle command:
 

--- a/conf/gradle/benchmarks.gradle
+++ b/conf/gradle/benchmarks.gradle
@@ -2,7 +2,8 @@ tasks.register("conditionallyUntarDataset") {
 	mustRunAfter compileBenchmarkTestJava
 
 	def tarFile = file("${layout.projectDirectory.asFile.absolutePath}/src/benchmarkTest/dataset.tar.gz")
-	def benchmarkTestDir = "${layout.buildDirectory.get().asFile.absolutePath}/resources/benchmarkTest"
+	// Don't extract to `build/resources/...`, Gradle would redundantly spend large amount of time processing the files
+	def benchmarkTestDir = "${layout.buildDirectory.get().asFile.absolutePath}/benchmarkTestDataset"
 	def targetDir = file(benchmarkTestDir)
 	def datasetDir = file("${benchmarkTestDir}/dataset")
 

--- a/conf/gradle/benchmarks.gradle
+++ b/conf/gradle/benchmarks.gradle
@@ -8,9 +8,12 @@ tasks.register("conditionallyUntarDataset") {
 	def datasetDir = file("${benchmarkTestDir}/dataset")
 
 	inputs.file(tarFile)
-	outputs.dir(targetDir)
+	outputs.upToDateWhen { datasetDir.exists() }
 
 	doLast {
+		// Keep this additional `datasetDir.exists()` check here despite it already being checked above,
+		// because Gradle might for other reasons consider the task to be not up-to-date, but in that case
+		// should not try to extract into existing dir; instead rely on user to delete it manually
 		if (!datasetDir.exists()) {
 			println "Untarring ${tarFile.name} to ${targetDir.absolutePath}"
 			copy {

--- a/src/benchmarkTest/java/io/github/azagniotov/language/Runner.java
+++ b/src/benchmarkTest/java/io/github/azagniotov/language/Runner.java
@@ -3,7 +3,6 @@ package io.github.azagniotov.language;
 import static io.github.azagniotov.language.benchmark.ThirdPartyDetector.detectorFor;
 import static java.lang.String.format;
 import static java.nio.file.Paths.get;
-import static java.util.Objects.requireNonNull;
 
 import io.github.azagniotov.language.annotations.GeneratedCodeClassCoverageExclusion;
 import io.github.azagniotov.language.benchmark.DetectorImpl;
@@ -29,8 +28,7 @@ public class Runner {
   private static final String ANSI_GREEN = "\u001B[32m";
 
   private static boolean verbose = false;
-  private static final String DIRECTORY_PATH =
-      requireNonNull(Runner.class.getResource("/dataset")).getPath();
+  private static final Path DATASET_DIRECTORY = get("build/benchmarkTestDataset/dataset");
 
   public static void main(final String[] args) {
 
@@ -49,10 +47,10 @@ public class Runner {
             + iso639_1Codes
             + ANSI_RESET);
     System.out.println(
-        "- Datasets parent directory absolute path: "
+        "- Datasets parent directory path: "
             + ANSI_BOLD
             + ANSI_CYAN
-            + DIRECTORY_PATH
+            + DATASET_DIRECTORY
             + ANSI_RESET);
     System.out.println("- Verbose mode: " + ANSI_BOLD + ANSI_CYAN + verbose + ANSI_RESET);
 
@@ -147,7 +145,7 @@ public class Runner {
       final Map<String, Map<String, Integer>> detectionCounts) {
     System.out.println(thirdPartyDetector.name() + " processes dataset [" + targetCode + "]");
 
-    final Path languageDatasetPath = get(format("%s/%s", DIRECTORY_PATH, targetCode));
+    final Path languageDatasetPath = DATASET_DIRECTORY.resolve(targetCode);
     if (!Files.exists(languageDatasetPath)) {
       System.out.println("\nLanguage dataset path is missing. Skipping detection.\n");
       throw new UncheckedIOException(new IOException("Language dataset path is missing."));
@@ -171,7 +169,7 @@ public class Runner {
                         detectionCounts.get(targetCode.toUpperCase());
                     countPerIsoCode.put(key, countPerIsoCode.getOrDefault(key, 0) + 1);
                   } catch (Exception e) {
-                    throw new RuntimeException(e);
+                    throw new RuntimeException("Failed processing: " + path, e);
                   }
                 });
       }


### PR DESCRIPTION
Closes #166

Otherwise Gradle will spend quite some time processing these test resources. Instead extract the dataset to a custom directory and have the benchmark directly read from that directory.

If possible, could you please give it a try locally as well to make sure it works for you as expected as well? Might also be good to move / delete your existing `build/resources/benchmarkTest/dataset` directory (assuming you had already extracted it) to make sure it is not picked up again by Gradle.

Also, please let me know if you want anything changed.