### PR TITLE
Fix exception for JFastTextDetector when language could not be detected

### DIFF
--- a/src/benchmarkTest/java/io/github/azagniotov/language/benchmark/JFastTextDetector.java
+++ b/src/benchmarkTest/java/io/github/azagniotov/language/benchmark/JFastTextDetector.java
@@ -41,6 +41,9 @@ public class JFastTextDetector implements ThirdPartyDetector {
   @Override
   public String detect(final String input) {
     final JFastText.ProbLabel probLabel = languageDetector.predictProba(input);
+    if (probLabel == null) {
+      return LANGUAGE_CODE_NONE;
+    }
 
     final String detectedIso639_1Code =
         probLabel.label.replaceAll(languageDetector.getLabelPrefix(), "");


### PR DESCRIPTION
Could happen when the input text is empty or too short. Though with the current benchmark dataset this did not occur.

The exception was:
```
...
Caused by: java.lang.NullPointerException: Cannot read field "label" because "probLabel" is null
        at io.github.azagniotov.language.benchmark.JFastTextDetector.detect(JFastTextDetector.java:48)
        at io.github.azagniotov.language.Runner.lambda$detectDataset$1(Runner.java:161)
        ... 13 more
```